### PR TITLE
Initial stats output

### DIFF
--- a/generate_diagrams.py
+++ b/generate_diagrams.py
@@ -10,14 +10,18 @@ except:
         data=json.load(f)
         
 words_per_day={}
+word_counts={}
     
 for d in data:
     words_length = len(d['text'])
     datestamp = d['date'].split("T")[0]
+    words_per_day[datestamp] = words_per_day.get(datestamp, 0) + words_length
+    
     try:
-        words_per_day[datestamp] += words_length
+        for word in d['text'].split():
+            word_counts[word] = word_counts.get(word, 0) + 1
     except:
-        words_per_day[datestamp] = words_length
+        pass
     
     
 avg_words_per_day=0
@@ -27,3 +31,4 @@ for day, word_length in words_per_day.items():
 avg_words_per_day /= len(words_per_day)
 
 print(f"Average words per day: {avg_words_per_day}")
+print(f"Top 10 occurrences of words: { { w:word_counts[w] for w in list(reversed(sorted(word_counts, key=word_counts.__getitem__)))[:10] } }")

--- a/generate_diagrams.py
+++ b/generate_diagrams.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+import json
+
+try:
+    with open('export.json') as f:
+        data=json.load(f)
+except:
+    print("Default data export not found, please provide a file path:")
+    with open(input("Telegram JSON export file: ")) as f:
+        data=json.load(f)
+        
+words_per_day={}
+    
+for d in data:
+    words_length = len(d['text'])
+    datestamp = d['date'].split("T")[0]
+    try:
+        words_per_day[datestamp] += words_length
+    except:
+        words_per_day[datestamp] = words_length
+    
+    
+avg_words_per_day=0
+for day, word_length in words_per_day.items():
+    avg_words_per_day += word_length
+    
+avg_words_per_day /= len(words_per_day)
+
+print(f"Average words per day: {avg_words_per_day}")


### PR DESCRIPTION
The telegram chat export isn't included here, but its structure is assumed to be consistent. Telegram produced a file named `export.json` which is what the file looks for.

A sample output:
```sh
$ ./generate_diagrams.py  
Average words per day: 5624.5026455026455
Top 10 occurrences of words: {'I': 18410, 'the': 17217, 'you': 15156, 'to': 14895, 'a': 14527, 'it': 9508, 'is': 8756, 'and': 8300, 'of': 7284, 'like': 6343}
```
More interesting datum to be developed, including the production of graphics likely via matplotlib